### PR TITLE
Move TimeExtension class methods that take a time to instance

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -38,7 +38,7 @@ module BusinessTime
 
     def calculate_after(time, days, options={})
       if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?(options)
-        time = Time.beginning_of_workday(time)
+        time = time.beginning_of_workday
       end
       while days > 0 || !time.workday?(options)
         days -= 1 if time.workday?(options)
@@ -47,14 +47,14 @@ module BusinessTime
       # If we have a Time or DateTime object, we can roll_forward to the
       #   beginning of the next business day
       if time.is_a?(Time) || time.is_a?(DateTime)
-        time = Time.roll_forward(time, options) unless time.during_business_hours?
+        time = time.roll_forward(options) unless time.during_business_hours?
       end
       time
     end
 
     def calculate_before(time, days, options={})
       if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?(options)
-        time = Time.beginning_of_workday(time)
+        time = time.beginning_of_workday
       end
       while days > 0 || !time.workday?(options)
         days -= 1 if time.workday?(options)
@@ -64,7 +64,7 @@ module BusinessTime
       #   beginning of the previous business day
       if time.is_a?(Time) || time.is_a?(DateTime)
         unless time.during_business_hours?
-          time = Time.beginning_of_workday(Time.roll_backward(time, options))
+          time = time.roll_backward(options).beginning_of_workday
         end
       end
       time

--- a/lib/business_time/business_hours.rb
+++ b/lib/business_time/business_hours.rb
@@ -39,10 +39,10 @@ module BusinessTime
     end
 
     def calculate_after(time, hours, options={})
-      after_time = Time.roll_forward(time, options)
+      after_time = time.roll_forward(options)
       # Step through the hours, skipping over non-business hours
       hours.times do
-        eod = Time.end_of_workday(after_time)
+        eod = after_time.end_of_workday
         after_time = after_time + 1.hour
 
         # Ignore hours before opening and after closing
@@ -52,7 +52,7 @@ module BusinessTime
           # Handle errors due to XX:59:59 exceptions
           delta = 0 if delta == 1.second
 
-          after_time = Time.roll_forward(after_time, options) + delta
+          after_time = after_time.roll_forward(options) + delta
         end
 
         # Ignore weekends and holidays
@@ -64,10 +64,10 @@ module BusinessTime
     end
 
     def calculate_before(time, hours, options={})
-      before_time = Time.roll_backward(time)
+      before_time = time.roll_backward
       # Step through the hours, skipping over non-business hours
       hours.times do
-        bod = Time.beginning_of_workday(before_time)
+        bod = before_time.beginning_of_workday
         before_time = before_time - 1.hour
 
         # Ignore hours before opening and after closing
@@ -75,7 +75,7 @@ module BusinessTime
           delta = bod - before_time
 
           # Due to the 23:59:59 end-of-workday exception
-          time_roll_backward = Time.roll_backward(before_time, options)
+          time_roll_backward = before_time.roll_backward(options)
           time_roll_backward += 1.second if time_roll_backward.iso8601 =~ /23:59:59/
 
           before_time = time_roll_backward - delta

--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -15,14 +15,92 @@ module BusinessTime
       BusinessTime::Config.weekdays.include?(wday)
     end
 
+    # TODO rdoc
+    def beginning_of_workday
+      beginning = BusinessTime::Config.beginning_of_workday(self)
+      self.change(
+        hour: beginning.hour,
+        min: beginning.min,
+        sec: beginning.sec
+      )
+    end
+
+    # TODO rdoc
+    def end_of_workday
+      ending = BusinessTime::Config.end_of_workday(self)
+      self.change(
+        hour: ending.hour,
+        min: ending.min,
+        sec: ending.sec
+      )
+    end
+
+    # TODO rdoc
+    def before_business_hours?
+      to_i < beginning_of_workday.to_i
+    end
+
+    # TODO rdoc
+    def after_business_hours?
+      to_i > end_of_workday.to_i
+    end
+
+    # Rolls forward to the next beginning_of_workday
+    # when the time is outside of business hours
+    def roll_forward(options={})
+      next_time = if before_business_hours? || !workday?(options)
+                    beginning_of_workday
+                  elsif after_business_hours? || end_of_workday == self
+                    (self + 1.day).beginning_of_workday
+                  else
+                    clone
+                  end
+
+      while !next_time.workday?(options)
+        next_time = (next_time + 1.day).beginning_of_workday
+      end
+
+      next_time
+    end
+
+    def first_business_day(options = {})
+      Time.first_business_day(self, options)
+    end
+
+    # Rolls backwards to the previous end_of_workday when the time is outside
+    # of business hours
+    def roll_backward(options={})
+      prev_time = if before_business_hours? || !workday?(options)
+                    (self - 1.day).end_of_workday
+                  elsif after_business_hours?
+                    end_of_workday
+                  else
+                    clone
+                  end
+
+      while !prev_time.workday?(options)
+        prev_time = (prev_time - 1.day).end_of_workday
+      end
+
+      prev_time
+    end
+
+    def previous_business_day(options = {})
+      Time.previous_business_day(self, options)
+    end
+
     module ClassMethods
       # Gives the time at the end of the workday, assuming that this time falls on a
       # workday.
       # Note: It pretends that this day is a workday whether or not it really is a
       # workday.
+      def deprecation_warning(message)
+        ActiveSupport::Deprecation.new("1.0", "business_time").warn(message)
+      end
+
       def end_of_workday(day)
-        end_of_workday = BusinessTime::Config.end_of_workday(day)
-        change_business_time(day,end_of_workday.hour,end_of_workday.min,end_of_workday.sec)
+        deprecation_warning("`Time.end_of_workday?(time)` is deprecated. Please use `time.end_of_workday`")
+        day.end_of_workday
       end
 
       # Gives the time at the beginning of the workday, assuming that this time
@@ -30,47 +108,38 @@ module BusinessTime
       # Note: It pretends that this day is a workday whether or not it really is a
       # workday.
       def beginning_of_workday(day)
-        beginning_of_workday = BusinessTime::Config.beginning_of_workday(day)
-        change_business_time(day,beginning_of_workday.hour,beginning_of_workday.min,beginning_of_workday.sec)
+        deprecation_warning("`Time.beginning_of_workday?(time)` is deprecated. Please use `time.beginning_of_workday`")
+        day.beginning_of_workday
       end
 
       # True if this time is on a workday (between 00:00:00 and 23:59:59), even if
       # this time falls outside of normal business hours.
       def workday?(day, options={})
-        ActiveSupport::Deprecation.warn("`Time.workday?(time)` is deprecated. Please use `time.workday?`")
+        deprecation_warning("`Time.workday?(time)` is deprecated. Please use `time.workday?`")
         day.workday?(options)
       end
 
       # True if this time falls on a weekday.
       def weekday?(day)
-        ActiveSupport::Deprecation.warn("`Time.weekday?(time)` is deprecated. Please use `time.weekday?`")
+        deprecation_warning("`Time.weekday?(time)` is deprecated. Please use `time.weekday?`")
         day.weekday?
       end
 
       def before_business_hours?(time)
-        time.to_i < beginning_of_workday(time).to_i
+        deprecation_warning("`Time.before_business_hours?(time)` is deprecated. Please use `time.before_business_hours`")
+        time.before_business_hours?
       end
 
       def after_business_hours?(time)
-        time.to_i > end_of_workday(time).to_i
+        deprecation_warning("`Time.after_business_hours?(time)` is deprecated. Please use `time.after_business_hours`")
+        time.after_business_hours?
       end
 
       # Rolls forward to the next beginning_of_workday
       # when the time is outside of business hours
       def roll_forward(time, options={})
-        if Time.before_business_hours?(time) || !time.workday?(options)
-          next_business_time = Time.beginning_of_workday(time)
-        elsif Time.after_business_hours?(time) || Time.end_of_workday(time) == time
-          next_business_time = Time.beginning_of_workday(time + 1.day)
-        else
-          next_business_time = time.clone
-        end
-
-        while !next_business_time.workday?(options)
-          next_business_time = Time.beginning_of_workday(next_business_time + 1.day)
-        end
-
-        next_business_time
+        deprecation_warning("`Time.roll_forward?(time)` is deprecated. Please use `time.roll_forward`")
+        options.roll_forward
       end
 
       # Returns the time parameter itself if it is a business day
@@ -86,19 +155,8 @@ module BusinessTime
       # Rolls backwards to the previous end_of_workday when the time is outside
       # of business hours
       def roll_backward(time, options={})
-        prev_business_time = if (Time.before_business_hours?(time) || !time.workday?(options))
-                               Time.end_of_workday(time - 1.day)
-                             elsif Time.after_business_hours?(time)
-                               Time.end_of_workday(time)
-                             else
-                               time.clone
-                             end
-
-        while !prev_business_time.workday?(options)
-          prev_business_time = Time.end_of_workday(prev_business_time - 1.day)
-        end
-
-        prev_business_time
+        deprecation_warning("`Time.roll_backwards?(time)` is deprecated. Please use `time.roll_backwards`")
+        options.roll_backward
       end
 
       # Returns the time parameter itself if it is a business day
@@ -152,25 +210,25 @@ module BusinessTime
       end
 
       # Align both times to the closest business hours
-      time_a = Time::roll_forward(time_a, options)
-      time_b = Time::roll_forward(time_b, options)
+      time_a = time_a.roll_forward(options)
+      time_b = time_b.roll_forward(options)
 
       if time_a.to_date == time_b.to_date
         time_b - time_a
       else
-        end_of_workday = Time.end_of_workday(time_a)
+        end_of_workday = time_a.end_of_workday
         end_of_workday += 1 if end_of_workday.to_s =~ /23:59:59/
 
         first_day       = end_of_workday - time_a
         days_in_between = ((time_a.to_date + 1)..(time_b.to_date - 1)).sum{ |day| Time::work_hours_total(day) }
-        last_day        = time_b - Time.beginning_of_workday(time_b)
+        last_day        = time_b - time_b.beginning_of_workday
 
         first_day + days_in_between + last_day
       end * direction
     end
 
     def during_business_hours?(options={})
-      self.workday?(options) && self.to_i.between?(Time.beginning_of_workday(self).to_i, Time.end_of_workday(self).to_i)
+      workday?(options) && to_i.between?(beginning_of_workday.to_i, end_of_workday.to_i)
     end
 
     def consecutive_workdays(options={})

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -70,13 +70,13 @@ describe "business hours" do
       it "roll forward to 9 am if asked in the early morning" do
         crack_of_dawn_monday = Time.parse("Mon Apr 26, 04:30:00, 2010")
         monday_morning = Time.parse("Mon Apr 26, 09:00:00, 2010")
-        assert_equal monday_morning, Time.roll_forward(crack_of_dawn_monday)
+        assert_equal monday_morning, crack_of_dawn_monday.roll_forward
       end
 
       it "roll forward to the next morning if aftern business hours" do
         monday_evening = Time.parse("Mon Apr 26, 18:00:00, 2010")
         tuesday_morning = Time.parse("Tue Apr 27, 09:00:00, 2010")
-        assert_equal tuesday_morning, Time.roll_forward(monday_evening)
+        assert_equal tuesday_morning, monday_evening.roll_forward
       end
 
       it "get the first business after the time that is not a business hour" do

--- a/test/test_business_hours_eastern.rb
+++ b/test/test_business_hours_eastern.rb
@@ -53,13 +53,13 @@ describe "business hours" do
       it "roll forward to 9 am if asked in the early morning" do
         crack_of_dawn_monday = Time.zone.parse("Mon Apr 26, 04:30:00, 2010")
         monday_morning = Time.zone.parse("Mon Apr 26, 09:00:00, 2010")
-        assert_equal monday_morning, Time.roll_forward(crack_of_dawn_monday)
+        assert_equal monday_morning, crack_of_dawn_monday.roll_forward
       end
 
       it "roll forward to the next morning if aftern business hours" do
         monday_evening = Time.zone.parse("Mon Apr 26, 18:00:00, 2010")
         tuesday_morning = Time.zone.parse("Tue Apr 27, 09:00:00, 2010")
-        assert_equal tuesday_morning, Time.roll_forward(monday_evening)
+        assert_equal tuesday_morning, monday_evening.roll_forward
       end
 
       it "consider any time on a weekend as equivalent to monday morning" do

--- a/test/test_business_hours_utc.rb
+++ b/test/test_business_hours_utc.rb
@@ -51,13 +51,13 @@ describe "business hours" do
       it "roll forward to 9 am if asked in the early morning" do
         crack_of_dawn_monday = Time.zone.parse("Mon Apr 26, 04:30:00, 2010")
         monday_morning = Time.zone.parse("Mon Apr 26, 09:00:00, 2010")
-        assert_equal monday_morning, Time.roll_forward(crack_of_dawn_monday)
+        assert_equal monday_morning, crack_of_dawn_monday.roll_forward
       end
 
       it "roll forward to the next morning if aftern business hours" do
         monday_evening = Time.zone.parse("Mon Apr 26, 18:00:00, 2010")
         tuesday_morning = Time.zone.parse("Tue Apr 27, 09:00:00, 2010")
-        assert_equal tuesday_morning, Time.roll_forward(monday_evening)
+        assert_equal tuesday_morning, monday_evening.roll_forward
       end
 
       it "consider any time on a weekend as equivalent to monday morning" do

--- a/test/test_business_time_until_eastern.rb
+++ b/test/test_business_time_until_eastern.rb
@@ -16,13 +16,13 @@ describe "#business_time_until" do
     it "should respect the time zone for TimeWithZone" do
       three_o_clock = Time.zone.parse("2014-02-17 15:00:00")
       nine_o_clock = Time.zone.parse("2014-02-17 09:00:00")
-      assert_equal nine_o_clock, Time.beginning_of_workday(three_o_clock)
+      assert_equal nine_o_clock, three_o_clock.beginning_of_workday
     end
 
     it "should respect the time zone for Time" do
       three_o_clock = Time.parse("2014-02-17 15:00:00")
       nine_o_clock = Time.parse("2014-02-17 09:00:00")
-      assert_equal nine_o_clock, Time.beginning_of_workday(three_o_clock)
+      assert_equal nine_o_clock, three_o_clock.beginning_of_workday
     end
   end
 end

--- a/test/test_time_extensions.rb
+++ b/test/test_time_extensions.rb
@@ -27,13 +27,13 @@ describe "time extensions" do
   it "know the beginning of the day for an instance" do
     first = Time.parse("August 17th, 2010, 11:50 am")
     expecting = Time.parse("August 17th, 2010, 9:00 am")
-    assert_equal expecting, Time.beginning_of_workday(first)
+    assert_equal expecting, first.beginning_of_workday
   end
 
   it "know the end of the day for an instance" do
     first = Time.parse("August 17th, 2010, 11:50 am")
     expecting = Time.parse("August 17th, 2010, 5:00 pm")
-    assert_equal expecting, Time.end_of_workday(first)
+    assert_equal expecting, first.end_of_workday
   end
 
   # ===================
@@ -99,26 +99,26 @@ describe "time extensions" do
     time = Time.parse("11pm UTC, Wednesday 9th May, 2012")
     workday_end = BusinessTime::Config.end_of_workday
     expected_time = Time.parse("#{workday_end} UTC, Wednesday 9th May, 2012")
-    assert_equal Time.roll_backward(time), expected_time
+    assert_equal time.roll_backward, expected_time
   end
 
   it "roll to the end of the previous day when before hours on a workday" do
     time = Time.parse("04am UTC, Wednesday 9th May, 2012")
     workday_end = BusinessTime::Config.end_of_workday
     expected_time = Time.parse("#{workday_end} UTC, Tuesday 8th May, 2012")
-    assert_equal Time.roll_backward(time), expected_time
+    assert_equal time.roll_backward, expected_time
   end
 
   it "rolls to the end of the previous workday on non-working days" do
     time = Time.parse("12pm UTC, Sunday 6th May, 2012")
     workday_end = BusinessTime::Config.end_of_workday
     expected_time = Time.parse("#{workday_end} UTC, Friday 4th May, 2012")
-    assert_equal Time.roll_backward(time), expected_time
+    assert_equal time.roll_backward, expected_time
   end
 
   it "returns the given time during working hours" do
     time = Time.parse("12pm, Tuesday 8th May, 2012")
-    assert_equal Time.roll_backward(time), time
+    assert_equal time.roll_backward, time
   end
 
   it "respects work hours" do
@@ -128,7 +128,7 @@ describe "time extensions" do
       :wed=>["9:00","12:00"],
       :sat=>["13:00","14:00"]
     }
-    assert_equal wednesday, Time.roll_backward(saturday)
+    assert_equal wednesday, saturday.roll_backward
   end
 
   it "know a holiday passed as a Date option is not a workday" do

--- a/test/test_time_with_zone_extensions.rb
+++ b/test/test_time_with_zone_extensions.rb
@@ -31,13 +31,13 @@ describe "TimeWithZone extensions" do
     it "know the beginning of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 9:00 am")
-      assert_equal expecting, Time.beginning_of_workday(first)
+      assert_equal expecting, first.beginning_of_workday
     end
 
     it "know the end of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 5:00 pm")
-      assert_equal expecting, Time.end_of_workday(first)
+      assert_equal expecting, first.end_of_workday
     end
 
     it "know a holiday passed as an option is not a workday" do
@@ -79,13 +79,13 @@ describe "TimeWithZone extensions" do
     it "know the beginning of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 9:00 am")
-      assert_equal expecting, Time.beginning_of_workday(first)
+      assert_equal expecting, first.beginning_of_workday
     end
 
     it "know the end of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 5:00 pm")
-      assert_equal expecting, Time.end_of_workday(first)
+      assert_equal expecting, first.end_of_workday
     end
 
     it "know a holiday passed as an option is not a workday" do


### PR DESCRIPTION
## Why?
### Moving methods from ClassMethods to instance methods
These methods are all essentially instance methods since they are called with an instance of the class, but the real reason for this is that having to type `Time.method(time)` instead of `time.method` is a lot of extra characters in situations where you want to chain these methods.

Example: `Time.beginning_of_workday(Time.roll_forward(time))` vs `time.roll_forward.beginning_of_workday`

### Deprecation Warnings
This I'm less sure of. I saw that these warnings were added in [PR #95](https://github.com/bokmann/business_time/pull/95) when `workday?` and `weekday?` were moved out like this and copied that pattern. However, I could see an argument that both ways of calling the methods are fine and shouldn't generate deprecation warnings.

## TODO
- [ ] Open this PR against the main gem