### PR TITLE
Properly handle overnight hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.3", "3.4"]
         bundler: [default]
         gemfile:
           - active_support_7
           - active_support_8
         include:
-          - { ruby: "2.3", gemfile: "active_support_3", bundler: "1" }
-          - { ruby: "2.4", gemfile: "active_support_4", bundler: "1" }
-          - { ruby: "2.5", gemfile: "active_support_4", bundler: "1" }
-          - { ruby: "2.5", gemfile: "active_support_5", bundler: "1" }
-          - { ruby: "2.6", gemfile: "active_support_5", bundler: "1" }
-          - { ruby: "2.6", gemfile: "active_support_6", bundler: "1" }
-          - { ruby: "2.7", gemfile: "active_support_6" }
-          - { ruby: "2.7", gemfile: "active_support_7" }
-          - { ruby: "3.0", gemfile: "active_support_7" }
-          - { ruby: "3.1", gemfile: "active_support_7" }
+          # Removed Ruby versions older than 3.3x as we're not using those
+          - { ruby: "3.3", gemfile: "active_support_7" }
+          - { ruby: "3.4", gemfile: "active_support_8" }
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
   test:
@@ -10,11 +17,9 @@ jobs:
         bundler: [default]
         gemfile:
           - active_support_7
-          - active_support_8
         include:
           # Removed Ruby versions older than 3.3x as we're not using those
           - { ruby: "3.3", gemfile: "active_support_7" }
-          - { ruby: "3.4", gemfile: "active_support_8" }
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/business_time.gemspec
+++ b/business_time.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdoc"
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-reporters"
+  s.add_development_dependency "debug"
 end

--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -37,36 +37,53 @@ module BusinessTime
     end
 
     def calculate_after(time, days, options={})
-      if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?(options)
-        time = Time.beginning_of_workday(time)
+      if !(time.is_a?(Date) || time.is_a?(DateTime) || time.is_a?(Time))
+        raise ArgumentError.new("BusinessDays can only be calculated from Date, DateTime, or Time objects")
       end
+
+      if !time.workday?(options)
+        time = Time.roll_forward(time, options)
+      end
+
       while days > 0 || !time.workday?(options)
         days -= 1 if time.workday?(options)
         time += 1.day
       end
+
       # If we have a Time or DateTime object, we can roll_forward to the
       #   beginning of the next business day
-      if time.is_a?(Time) || time.is_a?(DateTime)
-        time = Time.roll_forward(time, options) unless time.during_business_hours?
+      if !time.is_a?(Date) && !time.during_business_hours?
+        time = Time.roll_forward(time, options)
       end
+
       time
     end
 
+    def beginning_of_previous_workday(time, options={})
+      Time.beginning_of_workday(Time.roll_backward(time, options))
+    end
+
     def calculate_before(time, days, options={})
-      if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?(options)
-        time = Time.beginning_of_workday(time)
+      if !(time.is_a?(Date) || time.is_a?(DateTime) || time.is_a?(Time))
+        raise ArgumentError.new("BusinessDays can only be calculated from Date, DateTime, or Time objects")
       end
+
+      # Move to the beginning of the workday if we're starting on a non-workday
+      if !time.workday?(options)
+        time = beginning_of_previous_workday(time, options)
+      end
+
       while days > 0 || !time.workday?(options)
         days -= 1 if time.workday?(options)
         time -= 1.day
       end
-      # If we have a Time or DateTime object, we can roll_backward to the
-      #   beginning of the previous business day
-      if time.is_a?(Time) || time.is_a?(DateTime)
-        unless time.during_business_hours?
-          time = Time.beginning_of_workday(Time.roll_backward(time, options))
-        end
+
+      # If we have a Time or DateTime object, we can roll_forward to the
+      #   beginning of the next business day
+      if !time.is_a?(Date) && !time.during_business_hours?
+        time = beginning_of_previous_workday(time, options)
       end
+
       time
     end
   end

--- a/lib/business_time/business_hours.rb
+++ b/lib/business_time/business_hours.rb
@@ -64,7 +64,7 @@ module BusinessTime
     end
 
     def calculate_before(time, hours, options={})
-      before_time = Time.roll_backward(time)
+      before_time = Time.roll_backward(time, options)
       # Step through the hours, skipping over non-business hours
       hours.times do
         bod = Time.beginning_of_workday(before_time)

--- a/lib/business_time/business_hours.rb
+++ b/lib/business_time/business_hours.rb
@@ -14,7 +14,7 @@ module BusinessTime
       end
       self.hours <=> other.hours
     end
-    
+
     def ago(options={})
       Time.zone ? before(Time.zone.now, options) : before(Time.now, options)
     end
@@ -40,26 +40,33 @@ module BusinessTime
 
     def calculate_after(time, hours, options={})
       after_time = Time.roll_forward(time, options)
+
       # Step through the hours, skipping over non-business hours
-      hours.times do
-        eod = Time.end_of_workday(after_time)
+      hours.times do |time|
+        bod, eod = Time.work_day_boundaries(after_time, options)
+        eo_prev_day = Time.end_of_previous_day(after_time, options)
+        bo_next_day = Time.beginning_of_next_day(after_time, options)
         after_time = after_time + 1.hour
 
-        # Ignore hours before opening and after closing
-        if after_time > eod
+        delta = 0
+        if bod.nil?
+          if after_time >= eo_prev_day
+            # rolled over midnight into non-business day
+            delta = after_time.min * 60 + after_time.sec
+            after_time = bo_next_day
+          end
+        elsif after_time > eod
           delta = after_time - eod
-
-          # Handle errors due to XX:59:59 exceptions
-          delta = 0 if delta == 1.second
-
-          after_time = Time.roll_forward(after_time, options) + delta
+          after_time = bo_next_day
+        elsif after_time < bod && after_time >= eo_prev_day
+          delta = after_time - eo_prev_day
+          after_time = bod
         end
 
-        # Ignore weekends and holidays
-        while !after_time.workday?
-          after_time = after_time + 1.day
-        end
+        delta = 0 if delta == 1.second
+        after_time = after_time + delta
       end
+
       after_time
     end
 
@@ -67,25 +74,34 @@ module BusinessTime
       before_time = Time.roll_backward(time, options)
       # Step through the hours, skipping over non-business hours
       hours.times do
-        bod = Time.beginning_of_workday(before_time)
+        bod, eod = Time.work_day_boundaries(before_time, options)
+        eo_prev_day = Time.end_of_previous_day(before_time, options)
         before_time = before_time - 1.hour
 
-        # Ignore hours before opening and after closing
-        if before_time <= bod
+        delta = 0
+        if bod.nil?
+          if before_time >= eo_prev_day
+            # rolled over midnight into non-business day
+            # delta is how much time past midnight we went
+            delta += (60 - before_time.min) * 60 if before_time.min > 0
+            delta += (60 - before_time.sec) if before_time.sec > 0
+
+            before_time = eo_prev_day
+          end
+        elsif before_time < bod && before_time > eo_prev_day
           delta = bod - before_time
-
-          # Due to the 23:59:59 end-of-workday exception
-          time_roll_backward = Time.roll_backward(before_time, options)
-          time_roll_backward += 1.second if time_roll_backward.iso8601 =~ /23:59:59/
-
-          before_time = time_roll_backward - delta
+          before_time = eo_prev_day
+        elsif before_time > eod
+          delta = before_time - eod
+          before_time = eod
         end
 
-        # Ignore weekends and holidays
-        while !before_time.workday?
-          before_time = before_time - 1.day
-        end
+        before_time = before_time - delta
+
+        # Due to the 23:59:59 end-of-workday exception
+        before_time += 1.second if before_time.iso8601 =~ /59:59/
       end
+
       before_time
     end
   end

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -129,15 +129,18 @@ module BusinessTime
       # Return [ beginning_of_workday, end_of_workday ] for the given day.
       # Introduced for use in TimeExtensions to handle overnight work hours.
       def work_hours_for(day)
+        # Default return non-day-specific work hours
         eod = config[:end_of_workday]
+        bod = config[:beginning_of_workday]
+
+        # Override with day-specific work hours if given a day
         if day
           wday = work_hours[int_to_wday(day.wday)]
-          eod = wday.last if wday
-          bod = wday.first if wday
+          eod, bod = wday if wday
         end
 
         # Handle 00:00 closing times
-        eod == ParsedTime.new(0, 0) ? ParsedTime.new(23, 59, 59) : eod
+        # eod == ParsedTime.new(0, 0) ? ParsedTime.new(23, 59, 59) : eod
 
         return [eod, bod]
       end

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -111,7 +111,7 @@ module BusinessTime
       # Altered from gem definition!
       # - introduced work_hours_for(day)
       def end_of_workday(day=nil)
-        work_hours_for(day).first
+        work_hours_for(day).last
       end
 
       # You can set this yourself, either by the load method below, or
@@ -121,7 +121,7 @@ module BusinessTime
       # Altered from gem definition!
       # - introduced work_hours_for(day)
       def beginning_of_workday(day=nil)
-        work_hours_for(day).last
+        work_hours_for(day).first
       end
 
 
@@ -136,13 +136,15 @@ module BusinessTime
         # Override with day-specific work hours if given a day
         if day
           wday = work_hours[int_to_wday(day.wday)]
-          eod, bod = wday if wday
+          bod, eod = wday if wday
         end
 
         # Handle 00:00 closing times
-        # eod == ParsedTime.new(0, 0) ? ParsedTime.new(23, 59, 59) : eod
+        if eod == ParsedTime.new(0, 0)
+          eod = ParsedTime.new(23, 59, 59)
+        end
 
-        return [eod, bod]
+        return [bod, eod]
       end
 
       # You can set this yourself, either by the load method below, or

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -104,6 +104,23 @@ module BusinessTime
     threadsafe_cattr_accessor :fiscal_month_offset
 
     class << self
+      def weekday?(wday)
+        weekdays.include?(wday)
+      end
+
+
+      def holiday?(day, options={})
+        return false if day.nil?
+        holidays.include?(day.to_date) ||
+          to_array_of_dates(options[:holidays]).include?(day.to_date)
+      end
+
+
+      def workday?(time, options={})
+        weekday?(time.wday) && !holiday?(time, options)
+      end
+
+
       # You can set this yourself, either by the load method below, or
       # by saying
       #   BusinessTime::Config.end_of_workday = "5:30 pm"
@@ -128,16 +145,24 @@ module BusinessTime
       # Custom method (not in source gem)
       # Return [ beginning_of_workday, end_of_workday ] for the given day.
       # Introduced for use in TimeExtensions to handle overnight work hours.
-      def work_hours_for(day)
+      def work_hours_for(day, options={})
         # Default return non-day-specific work hours
-        eod = config[:end_of_workday]
-        bod = config[:beginning_of_workday]
+        if day.blank?
+          return [config[:beginning_of_workday], config[:end_of_workday]]
+        end
+
+        return [nil, nil] if !workday?(day, options)
+
+        if config[:work_hours].empty?
+          return [config[:beginning_of_workday], config[:end_of_workday]]
+        end
+
+        # todo probably regret
+        raise ArgumentError.new("day must be a Date or Time object if using work_hours configuration") if day && !day.respond_to?(:wday)
+
 
         # Override with day-specific work hours if given a day
-        if day
-          wday = work_hours[int_to_wday(day.wday)]
-          bod, eod = wday if wday
-        end
+        bod, eod = work_hours[int_to_wday(day.wday)]
 
         # Handle 00:00 closing times
         if eod == ParsedTime.new(0, 0)
@@ -226,6 +251,10 @@ module BusinessTime
 
       def deep_dup(object)
         Marshal.load(Marshal.dump(object))
+      end
+
+      def to_array_of_dates(values)
+        Array.wrap(values).map(&:to_date)
       end
     end
 

--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -20,18 +20,30 @@ module BusinessTime
       # workday.
       # Note: It pretends that this day is a workday whether or not it really is a
       # workday.
+      # Altered from gem definition! Handles overnight work hours
       def end_of_workday(day)
-        end_of_workday = BusinessTime::Config.end_of_workday(day)
-        change_business_time(day,end_of_workday.hour,end_of_workday.min,end_of_workday.sec)
+        bod, eod = BusinessTime::Config.work_hours_for(day)
+
+        if eod < bod # Handle overnight work hours
+          day = day + 1.day
+        end
+
+        change_business_time(day, eod.hour, eod.min, eod.sec)
       end
 
       # Gives the time at the beginning of the workday, assuming that this time
       # falls on a workday.
       # Note: It pretends that this day is a workday whether or not it really is a
       # workday.
+      # Altered from gem definition! Handles overnight work hours
       def beginning_of_workday(day)
-        beginning_of_workday = BusinessTime::Config.beginning_of_workday(day)
-        change_business_time(day,beginning_of_workday.hour,beginning_of_workday.min,beginning_of_workday.sec)
+        bod, eod = BusinessTime::Config.work_hours_for(day)
+
+        if eod < bod # Handle overnight work hours
+          day = day - 1.day
+        end
+
+        change_business_time(day, bod.hour, bod.min, bod.sec)
       end
 
       # True if this time is on a workday (between 00:00:00 and 23:59:59), even if

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -196,6 +196,28 @@ describe "business hours" do
         assert_equal two_after_open, 4.business_hours.after(two_before_close)
         assert_equal two_before_close, 4.business_hours.before(two_after_open)
       end
+
+
+      it "respects hours going over midnight" do
+        before_midnight = Time.parse("2025-11-12 23:00")
+        after_midnight = Time.parse("2025-11-13 01:00")
+
+        BusinessTime::Config.work_hours = {
+          mon: ["17:00", "02:00"],
+          tue: ["17:00", "02:00"],
+          wed: ["17:00", "02:00"],
+          thu: ["17:00", "02:00"],
+          fri: ["17:00", "02:00"],
+        }
+
+        assert_equal after_midnight, 2.business_hours.after(before_midnight)
+        assert_equal before_midnight, 2.business_hours.before(after_midnight)
+
+        next_shift = Time.parse("2025-11-13 18:00")
+
+        assert_equal next_shift, 2.business_hours.after(after_midnight)
+        assert_equal after_midnight, 2.business_hours.before(next_shift)
+      end
     end
 
     describe "when adding/subtracting negative number of business hours" do
@@ -363,6 +385,27 @@ describe "business hours" do
       assert_raises ArgumentError do
         -5.business_hours < -5.business_days
       end
+    end
+
+    it "respects hours going over midnight" do
+      before_midnight = Time.parse("2025-11-12 23:00")
+      after_midnight = Time.parse("2025-11-13 01:00")
+
+      BusinessTime::Config.work_hours = {
+        mon: ["17:00", "02:00"],
+        tue: ["17:00", "02:00"],
+        wed: ["17:00", "02:00"],
+        thu: ["17:00", "02:00"],
+        fri: ["17:00", "02:00"],
+      }
+
+      assert_equal before_midnight, -2.business_hours.after(after_midnight)
+      assert_equal after_midnight, -2.business_hours.before(before_midnight)
+
+      next_shift = Time.parse("2025-11-13 18:00")
+
+      assert_equal after_midnight, -2.business_hours.after(next_shift)
+      assert_equal next_shift, -2.business_hours.before(after_midnight)
     end
   end
 end

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -364,6 +364,5 @@ describe "business hours" do
         -5.business_hours < -5.business_days
       end
     end
-
   end
 end

--- a/test/test_business_hours_utc.rb
+++ b/test/test_business_hours_utc.rb
@@ -125,7 +125,7 @@ describe "business hours" do
         monday = Time.zone.parse("Mon Apr 26, 09:00:00, 2010")
         assert_equal(-1.business_hour.before(monday), -1.business_hour.before(sunday))
       end
-  
+
       it "take into account a holiday passed as an option" do
         three_day_weekend = Date.parse("July 5th, 2010")
         tuesday_morning = Time.zone.parse("July 6nd 2010, 9:50 am")

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -48,7 +48,7 @@ describe "config" do
       tue: [BusinessTime::ParsedTime.new(9),BusinessTime::ParsedTime.new(17)],
       thu: [BusinessTime::ParsedTime.new(9),BusinessTime::ParsedTime.new(17)],
       fri: [BusinessTime::ParsedTime.new(9),BusinessTime::ParsedTime.new(17)]
-    }, BusinessTime::Config.work_hours)
+    }.with_indifferent_access, BusinessTime::Config.work_hours)
     assert_equal([1,2,4,5], BusinessTime::Config.weekdays.sort)
   end
 
@@ -181,8 +181,8 @@ describe "config" do
     end
 
     it 'is threadsafe' do
-      old_hours = { fri: [BusinessTime::ParsedTime.new(10), BusinessTime::ParsedTime.new(12)] }
-      new_hours = { fri: [BusinessTime::ParsedTime.new(10), BusinessTime::ParsedTime.new(13)] }
+      old_hours = { fri: [BusinessTime::ParsedTime.new(10), BusinessTime::ParsedTime.new(12)] }.with_indifferent_access
+      new_hours = { fri: [BusinessTime::ParsedTime.new(10), BusinessTime::ParsedTime.new(13)] }.with_indifferent_access
       BusinessTime::Config.work_hours = old_hours
       t1 = Thread.new do
         sleep 0.1


### PR DESCRIPTION
Because we have to translate the working hours of any Vendor in CDP API (including Sock Club itself) to UTC times to properly handle business hours, we ended up with hours that went from "15:00" to "00:00", and the calculations for `9.business_hours.from_now` was going to be 9 business days later instead of 9 hours later.